### PR TITLE
Update obsidian.css

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -284,11 +284,29 @@ img
     padding-right: 10px !important;
 }
 
-.markdown-source-view,
-.markdown-preview-view,
-.workspace-leaf-header
+/* vertical resize-handle */
+.workspace-split.mod-vertical > * > .workspace-leaf-resize-handle,
+.workspace-split.mod-left-split > .workspace-leaf-resize-handle, 
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle
 {
-    border-left: 1px solid var(--background-secondary-alt) !important;
+    width: 1px !important;
+    background-color: var(--background-secondary-alt);
+}
+
+/* horizontal resize-handle */
+.workspace-split.mod-horizontal > * > .workspace-leaf-resize-handle
+{
+    height: 1px !important;
+    background-color: var(--background-secondary-alt);
+}
+
+/* Remove vertical split padding */
+.workspace-split.mod-root .workspace-split.mod-vertical .workspace-leaf-content,
+.workspace-split.mod-vertical > .workspace-split,
+.workspace-split.mod-vertical > .workspace-leaf,
+.workspace-tabs
+{
+    padding-right: 0px;
 }
 
 .markdown-embed-title

--- a/obsidian.css
+++ b/obsidian.css
@@ -284,7 +284,7 @@ img
     padding-right: 10px !important;
 }
 
-.cm-s-obsidian,
+.markdown-source-view,
 .markdown-preview-view,
 .workspace-leaf-header
 {


### PR DESCRIPTION
Fix the vertical separation line between notes which is misplaced since v0.7 release (new pane module).