### PR TITLE
Remove forceful img attributes

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -228,13 +228,6 @@ thead
     border-top-right-radius: 0 !important;
 }
 
-img
-{
-    display: block !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-}
-
 .HyperMD-list-line
 {
     padding-top: 0 !important;


### PR DESCRIPTION
Hi insanum,

I've created an emoji toolbar which and I assume other plugins also which might use `<img>` but not necessarily want these centered. If you don't require images to be centered forcefully as part of your theme, do you mind removing the proposed section.

Alternatively, to ensure your theme and mine and others' plugins work nicely, would you consider replacing the change rule with the following:

```
img.not(.emoji)
{
    display: block !important;
    margin-left: auto !important;
    margin-right: auto !important;
}
```
Thanks,

oliveryh