### PR TITLE
In settings, make text input placeholder distinguishable from a typed value

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -487,3 +487,9 @@ input.task-list-item-checkbox:checked {
     fill: var(--frost3) !important;
 }
 
+.setting-item-control input[type="text"] {
+    color: var(--text-normal);
+}
+.setting-item-control input[type="text"]::placeholder {
+    color: var(--dark3);
+}


### PR DESCRIPTION
I think it will be easiest to explain on an example. Here is the screenshot from CustomJS plugin settings where I have no value in the top input (you can see a placeholder value instead) and I have value in the bottom one. Both input look similar, there is no easy way to tell that the upper one is just a placeholder without any real value:

<img width="1403" alt="screenshot 2021-12-07 at 23 24 57" src="https://user-images.githubusercontent.com/92947323/145117263-35cf50ae-afac-41e4-a712-3c8a94170ab7.png">

Now take a look at a screenshot I made after adding my changes. Here placeholder uses way darker color:


<img width="1367" alt="screenshot 2021-12-07 at 23 37 11" src="https://user-images.githubusercontent.com/92947323/145117304-5ac5b739-639b-4c9a-b4ed-31185f2a8fb8.png">




