### PR TITLE
Improved table design

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -219,11 +219,30 @@ mark
     border-bottom-right-radius: 4px !important;
 }
 
-th
-{
+
+table {
+    border: 1px solid var(--background-secondary) !important;
+    border-collapse: collapse;
+}
+  
+th {
     font-weight: 600 !important;
+    border: 0px !important;
+    text-align: left;
+    background-color: rgba(0, 0, 0, 0.12);
+    color: var(--inline-code);
 }
 
+td {
+    border-left: 0px !important;
+    border-right: 0px !important;
+    border-bottom: 1px solid var(--background-secondary) !important;
+}
+
+tr:nth-child(even){ background-color: #3b4252b0; }
+tr:nth-child(odd){ background-color: rgba(0, 0, 0, 0.03) }
+tr:hover { background-color: var(--background-secondary-alt); }
+  
 thead
 {
     border-bottom: 2px solid var(--background-modifier-border) !important;

--- a/obsidian.css
+++ b/obsidian.css
@@ -56,6 +56,10 @@
     --text-selection:             var(--dark3);
     --text-tag:                   var(--frost0);
     --task-checkbox:              var(--frost0);
+    --table-header:               hsl(220, 16%, 16%);
+    --table-row-even:             hsl(220, 16%, 20%);
+    --table-row-odd:              hsl(220, 16%, 24%);
+    --table-hover:                var(--dark3);
 }
 .theme-light
 {
@@ -90,6 +94,10 @@
     --text-selection:             var(--light0);
     --text-tag:                   var(--frost2);
     --task-checkbox:              var(--frost0);
+    --table-header:               hsl(218, 27%, 48%);
+    --table-row-even:             hsl(220, 16%, 94%);
+    --table-row-odd:              hsl(220, 16%, 98%);
+    --table-hover:                var(--light1);
 }
 
 :root {
@@ -229,8 +237,8 @@ th {
     font-weight: 600 !important;
     border: 0px !important;
     text-align: left;
-    background-color: rgba(0, 0, 0, 0.12);
-    color: var(--inline-code);
+    background-color: var(--table-header);
+    color: var(--frost0);
 }
 
 td {
@@ -239,9 +247,9 @@ td {
     border-bottom: 1px solid var(--background-secondary) !important;
 }
 
-tr:nth-child(even){ background-color: #3b4252b0; }
-tr:nth-child(odd){ background-color: rgba(0, 0, 0, 0.03) }
-tr:hover { background-color: var(--background-secondary-alt); }
+tr:nth-child(even){ background-color: var(--table-row-even) }
+tr:nth-child(odd){ background-color: var(--table-row-odd) }
+tr:hover { background-color: var(--table-hover); }
   
 thead
 {


### PR DESCRIPTION
Hi,
based on [issue 26](https://github.com/insanum/obsidian_nord/issues/26) I updated the table design.

**Design principles:**
- Tables should not stand out too much from existing text, therefore no bright colors.
- In contrast to [issue 26](https://github.com/insanum/obsidian_nord/issues/26) I chose not to color-highlight the complete table, but went for a alternate-row design. This improves readability within large tables without the need of mouse hover.
- I tried to reuse as much existing colors as possible. This did not work out for the row backgrounds, though. Reason being that the brightness steps between e.g. dark1 and dark2 are quite big, this would lead to very "flashy" table colors (see also negative example image below). Are more sublte color grading was needed: Using the base colors "dark0" and "light2" I chose +2% brightness for odd rows and -2% percent for even rows. Headers got -4% brightness in dark mode, and -40% in light mode (otherwise having contast issues with font color). 

--------

**Light Theme: Original | New**
![theme-light](https://user-images.githubusercontent.com/1887246/160261515-d5a79d5a-5ff7-4c35-b2cc-585b9d7a51da.png)

**Dark Theme: Original | New**
![theme-dark](https://user-images.githubusercontent.com/1887246/160261534-515a179e-16f7-4539-8dd1-ab58a096d246.png)

---------

**Negative example why using dark1 & dark2 as bg-colors is not advised (table stands out too much):**
![theme-existing-colors](https://user-images.githubusercontent.com/1887246/160261544-914f2945-4b2e-45c8-9996-6a0d55fc7c23.png)

